### PR TITLE
Rename print flag to print-mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ struct Args {
 
     /// Print mode
     #[arg(long, value_enum, default_value_t = PrintMode::Full)]
-    print: PrintMode,
+    print_mode: PrintMode,
 
     /// Target architecture
     #[arg(long, value_enum, default_value_t = TargetId::X86)]
@@ -162,7 +162,7 @@ where
         panic!("No Impl found");
     };
     assert_eq!(results.len(), 1);
-    pprint(&results[0], args.print);
+    pprint(&results[0], args.print_mode);
     println!();
     let output = results[0].build(args.print_code)?.run()?;
     println!("Output: {}", String::from_utf8_lossy(&output.stdout));


### PR DESCRIPTION
I named this, but I always get confused... This name is obviously ambiguous, so let's rename it if that's okay for you.

**EDIT:**
I also realized `--print-mode` was very confusing with `--print-code`, just one char difference... Would you mind if I ask you for a better idea here?

`print` ->
* `print-mode`
* `print-style`
* `impl-style`

`print-code` ->
* `print-c`
* `show-c`
* `emit-c`