### PR TITLE
Support local target architecture

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -110,9 +110,9 @@ fn main() -> Result<()> {
     color::set_color_mode(args.color);
 
     let target_id = match &args.target_arch {
+        TargetArch::Local => local_target_id(),
         TargetArch::X86 => TargetId::X86,
         TargetArch::Arm => TargetId::Arm,
-        TargetArch::Local => local_target_id(),
     };
     match target_id {
         TargetId::X86 => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,7 @@ use morello::layout::Layout;
 use morello::pprint::{pprint, ImplPrintStyle};
 use morello::spec::{LogicalSpec, PrimitiveBasics, PrimitiveSpecType, Spec};
 use morello::table::{Database, DatabaseExt, InMemDatabase, SqliteDatabaseWrapper};
-use morello::target::{
-    get_target_id_for_local, ArmTarget, CpuMemoryLevel, Target, TargetId, X86Target,
-};
+use morello::target::{local_target_id, ArmTarget, CpuMemoryLevel, Target, TargetId, X86Target};
 use morello::tensorspec::TensorSpecAux;
 use morello::utils::ToWriteFmt;
 
@@ -114,7 +112,7 @@ fn main() -> Result<()> {
     let target_id = match &args.target_arch {
         TargetArch::X86 => TargetId::X86,
         TargetArch::Arm => TargetId::Arm,
-        TargetArch::Local => get_target_id_for_local(),
+        TargetArch::Local => local_target_id(),
     };
     match target_id {
         TargetId::X86 => {

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -63,10 +63,10 @@ pub enum TargetId {
 }
 
 #[cfg(target_arch = "x86_64")]
-pub fn get_target_id_for_local() -> TargetId {
+pub fn local_target_id() -> TargetId {
     TargetId::X86
 }
 #[cfg(target_arch = "aarch64")]
-pub fn get_target_id_for_local() -> TargetId {
+pub fn local_target_id() -> TargetId {
     TargetId::Arm
 }

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -14,7 +14,6 @@ use crate::memorylimits::MemoryLimits;
 use crate::scheduling::Action;
 use crate::spec::LogicalSpec;
 
-use clap::ValueEnum;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fmt::{Debug, Display};
@@ -57,7 +56,7 @@ pub trait MemoryLevel:
     }
 }
 
-#[derive(Clone, Copy, ValueEnum)]
+#[derive(Clone, Copy)]
 pub enum TargetId {
     X86,
     Arm,

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -61,3 +61,12 @@ pub enum TargetId {
     X86,
     Arm,
 }
+
+#[cfg(target_arch = "x86_64")]
+pub fn get_target_id_for_local() -> TargetId {
+    TargetId::X86
+}
+#[cfg(target_arch = "aarch64")]
+pub fn get_target_id_for_local() -> TargetId {
+    TargetId::Arm
+}


### PR DESCRIPTION
I often forget to supply `--target arm` when running Morello. This modification would save me future time, and I would very much appreciate it if you would approve this PR.

* Added `TargetArch` struct that involves `Local` in addition to `X86` and `Arm`
* Renamed `target` flag to `target_arch` and added its short flag
* Defaulted to `Local` for the `target_arch` flag
* Deleted `ValueEnum` derivation from `TargetId`