### PR TITLE
Implement -j/--jobs flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
  "log",
  "ndarray",
  "ndarray-conv",
+ "nonzero",
  "num-traits",
  "prettytable-rs",
  "proptest",
@@ -664,6 +665,18 @@ dependencies = [
  "ndarray",
  "rand",
  "rand_distr",
+]
+
+[[package]]
+name = "nonzero"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d9b9acd66930a3f7754cac98e17dbb17eb8018ad2c0b2e9ccccfbf23330127e"
+dependencies = [
+ "num-traits",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ snap = "1.1.0"
 tempfile = "3"
 thiserror = "1.0.47"
 thread_local = "1.1.7"
+nonzero = "0.2.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/benches/synth.rs
+++ b/benches/synth.rs
@@ -1,10 +1,10 @@
 use iai_callgrind::{black_box, main};
 use morello::db::DashmapDiskDatabase;
+use nonzero::nonzero as nz;
 use smallvec::smallvec;
 
 use morello::common::{DimSize, Dtype};
 use morello::layout::row_major;
-use morello::search::SINGLE_JOB;
 use morello::spec::{LogicalSpec, PrimitiveBasics, PrimitiveSpecType, Spec};
 use morello::target::{Target, X86Target};
 use morello::tensorspec::TensorSpecAux;
@@ -35,7 +35,7 @@ fn matmul_spec<Tgt: Target>(size: DimSize) -> Spec<Tgt> {
 
 fn synth(goal: &Spec<X86Target>) {
     let db = DashmapDiskDatabase::new(None, true, 1);
-    morello::search::top_down(&db, black_box(goal), 1, SINGLE_JOB);
+    morello::search::top_down(&db, black_box(goal), 1, Some(nz!(1usize)));
 }
 
 #[inline(never)]

--- a/benches/synth.rs
+++ b/benches/synth.rs
@@ -4,6 +4,7 @@ use smallvec::smallvec;
 
 use morello::common::{DimSize, Dtype};
 use morello::layout::row_major;
+use morello::search::SINGLE_JOB;
 use morello::spec::{LogicalSpec, PrimitiveBasics, PrimitiveSpecType, Spec};
 use morello::target::{Target, X86Target};
 use morello::tensorspec::TensorSpecAux;
@@ -34,7 +35,7 @@ fn matmul_spec<Tgt: Target>(size: DimSize) -> Spec<Tgt> {
 
 fn synth(goal: &Spec<X86Target>) {
     let db = DashmapDiskDatabase::new(None, true, 1);
-    morello::search::top_down(&db, black_box(goal), 1, false);
+    morello::search::top_down(&db, black_box(goal), 1, SINGLE_JOB);
 }
 
 #[inline(never)]

--- a/src/bin/precompute.rs
+++ b/src/bin/precompute.rs
@@ -15,6 +15,7 @@ use morello::datadeps::SpecKey;
 use morello::db::{DashmapDiskDatabase, Database};
 use morello::grid::general::SurMap;
 use morello::memorylimits::{MemVec, MemoryLimits};
+use morello::search::SINGLE_JOB;
 use morello::spec::{
     LogicalSpec, LogicalSpecSurMap, PrimitiveBasics, PrimitiveBasicsBimap, PrimitiveSpecType, Spec,
 };
@@ -169,7 +170,7 @@ where
                 worklist.push_back(top.clone());
                 while let Some(job) = worklist.pop_front() {
                     let spec = Spec(logical_spec.clone(), MemoryLimits::Standard(job));
-                    let result = morello::search::top_down(db, &spec, 1, false);
+                    let result = morello::search::top_down(db, &spec, 1, SINGLE_JOB);
                     if let [(_, only_result_cost)] = &result.0[..] {
                         worklist.extend(next_limits(&spec.1, &only_result_cost.peaks));
                     }

--- a/src/bin/precompute.rs
+++ b/src/bin/precompute.rs
@@ -3,6 +3,7 @@ use tikv_jemallocator::Jemalloc;
 
 use clap::Parser;
 use log::{debug, info};
+use nonzero::nonzero as nz;
 use rand::seq::SliceRandom;
 use rayon::prelude::*;
 use smallvec::{smallvec, SmallVec};
@@ -15,7 +16,6 @@ use morello::datadeps::SpecKey;
 use morello::db::{DashmapDiskDatabase, Database};
 use morello::grid::general::SurMap;
 use morello::memorylimits::{MemVec, MemoryLimits};
-use morello::search::SINGLE_JOB;
 use morello::spec::{
     LogicalSpec, LogicalSpecSurMap, PrimitiveBasics, PrimitiveBasicsBimap, PrimitiveSpecType, Spec,
 };
@@ -170,7 +170,7 @@ where
                 worklist.push_back(top.clone());
                 while let Some(job) = worklist.pop_front() {
                     let spec = Spec(logical_spec.clone(), MemoryLimits::Standard(job));
-                    let result = morello::search::top_down(db, &spec, 1, SINGLE_JOB);
+                    let result = morello::search::top_down(db, &spec, 1, Some(nz!(1usize)));
                     if let [(_, only_result_cost)] = &result.0[..] {
                         worklist.extend(next_limits(&spec.1, &only_result_cost.peaks));
                     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -34,7 +34,7 @@ where
 
     let thread_count = jobs
         .map(|j| j.get())
-        .unwrap_or_else(|| rayon::current_num_threads());
+        .unwrap_or_else(rayon::current_num_threads);
     if thread_count == 1 {
         return top_down_spec(db, goal, top_k, 0, 1);
     }


### PR DESCRIPTION
This patch now accepts a -j/--jobs flag to handle parallelism for
top-down search.