### PR TITLE
Make DashmapDiskDatabase constructors return result

### DIFF
--- a/benches/synth.rs
+++ b/benches/synth.rs
@@ -33,7 +33,7 @@ fn matmul_spec<Tgt: Target>(size: DimSize) -> Spec<Tgt> {
 }
 
 fn synth(goal: &Spec<X86Target>) {
-    let db = DashmapDiskDatabase::new(None, true, 1);
+    let db = DashmapDiskDatabase::try_new(None, true, 1).unwrap();
     morello::search::top_down(&db, black_box(goal), 1, false);
 }
 

--- a/src/bin/analyzedb.rs
+++ b/src/bin/analyzedb.rs
@@ -2,6 +2,7 @@ use itertools::Itertools;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 
+use anyhow::Result;
 use clap::Parser;
 use std::{iter, path, thread};
 
@@ -53,9 +54,9 @@ fn block_stats(block: &DbBlock) -> String {
     }
 }
 
-fn main() {
+fn main() -> Result<()> {
     let args = Args::parse();
-    let db = DashmapDiskDatabase::new(args.db.as_deref(), true, 1);
+    let db = DashmapDiskDatabase::try_new(args.db.as_deref(), true, 1)?;
     let bimap = db.spec_bimap();
     let p = if args.group { "      " } else { "" };
 
@@ -148,4 +149,6 @@ fn main() {
             }
         }
     }
+
+    Ok(())
 }

--- a/src/bin/precompute.rs
+++ b/src/bin/precompute.rs
@@ -1,6 +1,7 @@
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 
+use anyhow::Result;
 use clap::Parser;
 use log::{debug, info};
 use rand::seq::SliceRandom;
@@ -50,12 +51,18 @@ struct Args {
     size: DimSize,
 }
 
-fn main() {
+fn main() -> Result<()> {
     env_logger::init();
     let args = Args::parse();
-    let db =
-        DashmapDiskDatabase::with_capacity(args.db.as_deref(), true, K, INITIAL_HASHMAP_CAPACITY);
+    let db = DashmapDiskDatabase::try_with_capacity(
+        args.db.as_deref(),
+        true,
+        K,
+        INITIAL_HASHMAP_CAPACITY,
+    )?;
     main_per_db(&args, &db);
+
+    Ok(())
 }
 
 fn main_per_db<'a, D>(args: &Args, db: &'a D)

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn main() -> Result<()> {
     env_logger::init();
     let args = Args::parse();
     color::set_color_mode(args.color);
-    let db = DashmapDiskDatabase::new(args.db.as_deref(), BINARY_SCALE_SHAPES, K.into());
+    let db = DashmapDiskDatabase::try_new(args.db.as_deref(), BINARY_SCALE_SHAPES, K.into())?;
     match &args.target {
         TargetId::X86 => main_per_db::<_, X86Target>(&args, &db),
         TargetId::Arm => main_per_db::<_, ArmTarget>(&args, &db),

--- a/src/search.rs
+++ b/src/search.rs
@@ -218,7 +218,7 @@ mod tests {
         fn test_can_synthesize_any_spec(
             spec in any_with::<Spec<X86Target>>((Some(TEST_SMALL_SIZE), Some(TEST_SMALL_MEM)))
         ) {
-            let db = DashmapDiskDatabase::new(None, false, 1);
+            let db = DashmapDiskDatabase::try_new(None, false, 1).unwrap();
             top_down(&db, &spec, 1, false);
         }
 
@@ -227,7 +227,7 @@ mod tests {
             spec_pair in lower_and_higher_spec::<X86Target>()
         ) {
             let (spec, raised_spec) = spec_pair;
-            let db = DashmapDiskDatabase::new(None, false, 1);
+            let db = DashmapDiskDatabase::try_new(None, false, 1).unwrap();
 
             // Solve the first, lower Spec.
             let (lower_result_vec, _, _) = top_down(&db, &spec, 1, false);
@@ -249,7 +249,7 @@ mod tests {
         fn test_synthesis_at_peak_memory_yields_same_decision(
             spec in any_with::<Spec<X86Target>>((Some(TEST_SMALL_SIZE), Some(TEST_SMALL_MEM)))
         ) {
-            let db = DashmapDiskDatabase::new(None, false, 1);
+            let db = DashmapDiskDatabase::try_new(None, false, 1).unwrap();
             let (first_solutions, _, _) = top_down(&db, &spec, 1, false);
             let first_peak = if let Some(first_sol) = first_solutions.first() {
                 first_sol.1.peaks.clone()
@@ -283,7 +283,7 @@ mod tests {
             MemoryLimits::Standard(MemVec::new_from_binary_scaled([0, 5, 7, 6])),
         );
 
-        let db = DashmapDiskDatabase::new(None, false, 1);
+        let db = DashmapDiskDatabase::try_new(None, false, 1).unwrap();
         let (first_solutions, _, _) = top_down(&db, &spec, 1, false);
         let first_peak = if let Some(first_sol) = first_solutions.first() {
             first_sol.1.peaks.clone()


### PR DESCRIPTION
This patch resolves the TODO comment in DashmapDiskDatabase.  All
constructors now return anyhow::Result, and I added handling on the
caller side.  Also, all constructors have been prefixed with `try_` since
they return a result, which corresponds to the Rust's standard library:

https://doc.rust-lang.org/std/boxed/struct.Box.html#method.try_new

---

Please let me know if this is not an intended fix!