### PR TITLE
Removed unnecessary TODO comment for shape.

### DIFF
--- a/morello/src/tensorspec.rs
+++ b/morello/src/tensorspec.rs
@@ -17,7 +17,7 @@ use crate::utils::join_into_string;
 #[derive(Clone, PartialEq, Eq, Debug, Hash, Deserialize, Serialize)]
 #[serde(bound = "")]
 pub struct TensorSpec<Tgt: Target> {
-    pub shape: Shape, // TODO: Rename to shape
+    pub shape: Shape,
     pub dtype: Dtype,
     pub aux: TensorSpecAux<Tgt>,
 }


### PR DESCRIPTION
The TODO comment says to rename a field to shape, but it is already called shape.