### PR TITLE
Optimized canonicalization.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +439,19 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -459,7 +482,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "env_logger",
+ "env_logger 0.10.2",
  "log",
  "morello",
  "nonzero",
@@ -976,7 +999,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "env_logger",
+ "env_logger 0.11.3",
  "log",
  "morello",
  "nonzero",

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -183,7 +183,7 @@ where
             size,
         } => {
             let rm = row_major(4);
-            LogicalSpec::Primitive(
+            LogicalSpec::new_primitive(
                 PrimitiveBasics {
                     typ: PrimitiveSpecType::Conv { accum: false },
                     spec_shape: smallvec![
@@ -209,10 +209,12 @@ where
                 ],
                 true,
             )
+            .try_into_canon()
+            .unwrap()
         }
     };
 
-    let spec = Spec(logical_spec, Tgt::max_mem());
+    let spec = Spec::new(logical_spec, Tgt::max_mem()).into_canon();
     info!("Synthesizing {}", spec);
 
     let start_time = std::time::Instant::now();

--- a/morello/benches/synth.rs
+++ b/morello/benches/synth.rs
@@ -19,7 +19,7 @@ fn matmul_spec<Tgt: Target>(size: u32) -> Spec<Tgt> {
         (u32, Tgt::default_level(), rm2),
         serial
     ));
-    Spec(logical_spec, X86Target::max_mem())
+    Spec::new(logical_spec, X86Target::max_mem()).into_canon()
 }
 
 fn synth(goal: &Spec<X86Target>) {

--- a/morello/examples/matvec_gemma_x86_bf16f32.rs
+++ b/morello/examples/matvec_gemma_x86_bf16f32.rs
@@ -25,7 +25,7 @@ fn main() {
 
     // Let's construct a multi-threaded matrix-matrix multiplication which takes two bf16
     // matrices and produces a f32 matrix.
-    let spec = Spec::<X86Target>(
+    let spec = Spec::<X86Target>::new(
         lspec!(Matmul(
             [M, K, N],
             (bf16, GL, row_major(2)),
@@ -33,7 +33,8 @@ fn main() {
             (f32, GL, row_major(2))
         )),
         X86Target::max_mem(),
-    );
+    )
+    .into_canon();
 
     // Manually schedule the matrix multiplication.
     let interleaved = Layout::new(smallvec![

--- a/morello/examples/simple_matmul.rs
+++ b/morello/examples/simple_matmul.rs
@@ -30,7 +30,7 @@ fn main() {
     // (VRF), so it is `None` below.
     let layout = row_major(2);
 
-    let spec = Spec::<X86Target>(
+    let spec = Spec::<X86Target>::new(
         lspec!(Matmul(
             [64, 64, 64],
             (u32, GL, layout.clone()),
@@ -39,7 +39,8 @@ fn main() {
             serial
         )),
         X86Target::max_mem(),
-    );
+    )
+    .into_canon();
     println!("Logical Spec: {}", spec.0);
 
     // Manually schedule the matrix multiplication.

--- a/morello/src/alignment.rs
+++ b/morello/src/alignment.rs
@@ -65,7 +65,7 @@ mod tests {
     fn test_aligned_approx_x86() {
         // TODO: Make sure to test different dtypes.
 
-        let parent = TensorSpec::<X86Target>::new_canon(
+        let parent = TensorSpec::<X86Target>::new(
             shape![16, 16, 16],
             Dtype::Uint8,
             row_major(3).contiguous_full(),
@@ -73,7 +73,9 @@ mod tests {
             CpuMemoryLevel::GL,
             row_major(3),
             None,
-        );
+        )
+        .try_into_canon()
+        .unwrap();
         let layout = parent.layout();
 
         // TODO: Allocate a buffer which is aligned, or not, according to `parent.aligned()`.

--- a/morello/src/pprint.rs
+++ b/morello/src/pprint.rs
@@ -193,8 +193,11 @@ mod tests {
             .into_iter()
             .enumerate()
             .map(|(i, ts)| Param::new(i.try_into().unwrap(), ts));
-        let spec_app: ImplNode<X86Target> =
-            SpecApp::new(Spec(logical_spec, X86Target::max_mem()), args).into();
+        let spec_app: ImplNode<X86Target> = SpecApp::new(
+            Spec::new(logical_spec, X86Target::max_mem()).into_canon(),
+            args,
+        )
+        .into();
         pprint(&spec_app, ImplPrintStyle::Full);
         pprint(&spec_app, ImplPrintStyle::Compact);
     }

--- a/morello/src/target/cpu.rs
+++ b/morello/src/target/cpu.rs
@@ -65,7 +65,7 @@ pub enum CpuKernel {
     /// ```text
     ///                        0 1 2 3
     ///      0 1 2 3           4 5 6 7
-    ///      4 5 6 7       a b    
+    ///      4 5 6 7       a b
     /// a b            →   a b
     ///                    a b
     ///                    a b
@@ -1237,7 +1237,7 @@ mod tests {
         let rm2 = row_major(2);
         let cm2 = col_major(2);
         let operands = [
-            TensorSpec::<X86Target>::new_canon(
+            TensorSpec::<X86Target>::new(
                 shape![1, 2],
                 Dtype::Uint8,
                 rm2.contiguous_full(),
@@ -1245,8 +1245,10 @@ mod tests {
                 CpuMemoryLevel::L1,
                 rm2.clone(),
                 None,
-            ),
-            TensorSpec::<X86Target>::new_canon(
+            )
+            .try_into_canon()
+            .unwrap(),
+            TensorSpec::<X86Target>::new(
                 shape![2, 16],
                 Dtype::Sint8,
                 cm2.contiguous_full(),
@@ -1254,8 +1256,10 @@ mod tests {
                 CpuMemoryLevel::VRF,
                 cm2,
                 Some(nz!(32u32)),
-            ),
-            TensorSpec::<X86Target>::new_canon(
+            )
+            .try_into_canon()
+            .unwrap(),
+            TensorSpec::<X86Target>::new(
                 shape![1, 16],
                 Dtype::Sint16,
                 rm2.contiguous_full(),
@@ -1263,7 +1267,9 @@ mod tests {
                 CpuMemoryLevel::VRF,
                 rm2.clone(),
                 Some(nz!(16u32)),
-            ),
+            )
+            .try_into_canon()
+            .unwrap(),
         ];
         assert!(CpuKernel::TwoVecBroadcastVecMultAddU8S8S16.applies_to_parameters(&operands))
     }


### PR DESCRIPTION
This patch introduces `NonCanon<T>` type, which wraps `LogicalSpec` and `TensorSpec`.  This update removed almost all is_canonical methods and potential redundant `canonicalize` method calls.  To change types to `NonCanon` and minimize clone, move was required for `try_into_canon` and other mutation methods.  Since `TensorSpecAux`'s canonicalization status depends on its parent's shape, it is not wrapped by `NonCanon`.

### Performance

I used iai_callgrind to take the benchmark, and here is the result:

Before: 2544949
After: 951321b8797fbf6a4627585801c3a6e2e10cda93

```
synth::synth_matmul_benchmark_1
  Instructions:            86544920 (-22.51599%)
  L1 Data Hits:            31523739 (-20.65469%)
  L2 Hits:                  1821879 (+14.86511%)
  RAM Hits:                   64099 (+8.935946%)
  Total read+write:       119954637 (-21.63344%)
```

### Notes

* I did not use `try_into()` to convert NonCanon types to canonical types because I think it makes things unclear.
* I added `new_primitive` to construct a NonCanon<LogicalSpec> and avoided direct construction. When we construct a new LogicalSpec, we should ensure that we are not using direction construction unless we are sure that it is canonical.
* I removed `new_canon` and `new_noncanon` methods from `TensorSpec` so that `new` means create NonCanon types just like `new_primitive`. This is also because we no longer need a temporary variable to make spec canonical.
* I implemented `replace_io` and `set_serial_only` for `NonCanon<LogicalSpec<>>` as wrapper functions. These methods are to avoid having to deal with move over `Deref`.