### PR TITLE
Migrated to new iai_callgrind syntax.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,6 +70,7 @@ jobs:
           sudo apt-fast update -qq
           DEBIAN_FRONTEND='noninteractive' sudo apt install --no-install-recommends -yq valgrind
       - uses: actions/checkout@v4
-      - run: cargo install --version 0.4.0 iai-callgrind-runner
+      - run: cargo install --version 0.11.0 iai-callgrind-runner
       - name: Run benchmarks
         run: cargo bench --verbose
+        working-directory: morello

--- a/morello/benches/iter_actions.rs
+++ b/morello/benches/iter_actions.rs
@@ -1,4 +1,4 @@
-use iai_callgrind::main;
+use iai_callgrind::{library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig};
 use std::hint::black_box;
 
 use morello::layout::row_major;
@@ -7,7 +7,7 @@ use morello::spec::{LogicalSpec, PrimitiveBasics, PrimitiveSpecType};
 use morello::target::{CpuMemoryLevel::GL, X86Target};
 use morello::tensorspec::TensorSpecAux;
 
-#[inline(never)]
+#[library_benchmark]
 fn copy_actions_into_vec() {
     let rm2 = row_major(2);
     let logical_spec: LogicalSpec<X86Target> = lspec!(Matmul(
@@ -20,8 +20,16 @@ fn copy_actions_into_vec() {
     black_box(logical_spec.actions().into_iter().collect::<Vec<_>>());
 }
 
+library_benchmark_group!(
+    name = iter_actions_group;
+    benchmarks = copy_actions_into_vec
+);
+
 main!(
-    callgrind_args = "--simulate-wb=no", "--simulate-hwpref=yes",
-        "--I1=32768,8,64", "--D1=32768,8,64", "--LL=8388608,16,64";
-    functions = copy_actions_into_vec
+    config = LibraryBenchmarkConfig::default()
+                .raw_callgrind_args([
+                    "--simulate-wb=no", "--simulate-hwpref=yes",
+                    "--I1=32768,8,64", "--D1=32768,8,64", "--LL=8388608,16,64",
+                ]);
+    library_benchmark_groups = iter_actions_group
 );

--- a/morello/benches/logicalspec_parameters.rs
+++ b/morello/benches/logicalspec_parameters.rs
@@ -1,4 +1,4 @@
-use iai_callgrind::main;
+use iai_callgrind::{library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig};
 use std::hint::black_box;
 
 use morello::layout::row_major;
@@ -44,7 +44,7 @@ fn move_spec<Tgt: Target>(size: u32) -> LogicalSpec<Tgt> {
     ))
 }
 
-#[inline(never)]
+#[library_benchmark]
 fn iter_logicalspec_parameters_matmul() {
     let sp = matmul_spec::<X86Target>(32);
     for _ in 0..100 {
@@ -54,7 +54,7 @@ fn iter_logicalspec_parameters_matmul() {
     }
 }
 
-#[inline(never)]
+#[library_benchmark]
 fn iter_logicalspec_parameters_conv() {
     let sp = conv_spec::<X86Target>(32);
     for _ in 0..100 {
@@ -64,7 +64,7 @@ fn iter_logicalspec_parameters_conv() {
     }
 }
 
-#[inline(never)]
+#[library_benchmark]
 fn iter_logicalspec_parameters_move() {
     let sp = move_spec::<X86Target>(32);
     for _ in 0..100 {
@@ -74,12 +74,22 @@ fn iter_logicalspec_parameters_move() {
     }
 }
 
-main!(
-    callgrind_args = "toggle-collect=morello_bench_logicalspec_parameters::matmul_spec",
-        "toggle-collect=morello_bench_logicalspec_parameters::conv_spec",
-        "toggle-collect=morello_bench_logicalspec_parameters::move_spec",
-        "--simulate-wb=no", "--simulate-hwpref=yes",
-        "--I1=32768,8,64", "--D1=32768,8,64", "--LL=8388608,16,64";
-    functions = iter_logicalspec_parameters_matmul, iter_logicalspec_parameters_conv,
+library_benchmark_group!(
+    name = logicalspec_parameters_group;
+    benchmarks =
+        iter_logicalspec_parameters_matmul,
+        iter_logicalspec_parameters_conv,
         iter_logicalspec_parameters_move
+);
+
+main!(
+    config = LibraryBenchmarkConfig::default()
+                .raw_callgrind_args([
+                    "toggle-collect=morello_bench_logicalspec_parameters::matmul_spec",
+                    "toggle-collect=morello_bench_logicalspec_parameters::conv_spec",
+                    "toggle-collect=morello_bench_logicalspec_parameters::move_spec",
+                    "--simulate-wb=no", "--simulate-hwpref=yes",
+                    "--I1=32768,8,64", "--D1=32768,8,64", "--LL=8388608,16,64",
+                ]);
+    library_benchmark_groups = logicalspec_parameters_group
 );

--- a/morello/benches/update_for_tiling.rs
+++ b/morello/benches/update_for_tiling.rs
@@ -1,9 +1,9 @@
-use iai_callgrind::main;
+use iai_callgrind::{library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig};
 use std::hint::black_box;
 
 use morello::{layout, shape};
 
-#[inline(never)]
+#[library_benchmark]
 fn update_for_tiling() {
     let shape = shape![64, 64, 64];
     let tile_shape = shape![64, 8, 8];
@@ -17,8 +17,16 @@ fn update_for_tiling() {
     black_box(layout.update_for_tiling(&shape, &tile_shape, c)).unwrap();
 }
 
+library_benchmark_group!(
+    name = update_for_tiling_group;
+    benchmarks = update_for_tiling
+);
+
 main!(
-    callgrind_args = "--simulate-wb=no", "--simulate-hwpref=yes",
-        "--I1=32768,8,64", "--D1=32768,8,64", "--LL=8388608,16,64";
-    functions = update_for_tiling
+    config = LibraryBenchmarkConfig::default()
+                .raw_callgrind_args([
+                    "--simulate-wb=no", "--simulate-hwpref=yes",
+                    "--I1=32768,8,64", "--D1=32768,8,64", "--LL=8388608,16,64",
+                ]);
+    library_benchmark_groups = update_for_tiling_group
 );


### PR DESCRIPTION
Since `#[library_benchmark]` does not allow any other attributes provided by iai_callgrind, I omitted `#[inline(never)]`.  However, `#[inline(never)]` will be automatically added by the macro.  Here's the output of `cargo expand --bench impl_reducer` in case you are concerned.

```rs
    // truncated ...

    #[inline(never)]
    #[export_name = "iai_callgrind::bench::reduce_costs"]
    fn reduce_costs(k: u16) {
        let (entries, mut reducer) = black_box(init_reduce_costs(black_box(k)));
        for (action_idx, cost) in entries {
            reducer.insert(black_box(action_idx), black_box(cost));
        }
    }
    #[inline(never)]
    pub fn multiple_0() {
        let _ = std::hint::black_box(reduce_costs(std::hint::black_box(1)));
    }
    #[inline(never)]
    pub fn multiple_1() {
        let _ = std::hint::black_box(reduce_costs(std::hint::black_box(2)));
    }
    #[inline(never)]
    pub fn multiple_2() {
        let _ = std::hint::black_box(reduce_costs(std::hint::black_box(8)));
    }
    #[inline(never)]
    pub fn multiple_3() {
        let _ = std::hint::black_box(reduce_costs(std::hint::black_box(100)));
    }
```