### PR TITLE
Reduced runtime nonzero checks.

### DIFF
--- a/morello/src/codegen/cpu.rs
+++ b/morello/src/codegen/cpu.rs
@@ -1,5 +1,4 @@
 use itertools::{Either, Itertools};
-use nonzero::nonzero as nz;
 use std::collections::HashMap;
 use std::fmt::{self, Write};
 use std::iter;
@@ -18,7 +17,6 @@ use crate::imp::Impl;
 use crate::imp::ImplNode;
 use crate::layout::BufferVar;
 use crate::pprint::{pprint_write, ImplPrintStyle};
-use crate::shape;
 use crate::target::cpu::{DOT_PRODUCT_BF16_ACCUM_COUNT, DOT_PRODUCT_BF16_STRIP_SIZE};
 use crate::target::{
     cpu::{DOT_PRODUCT_ACCUM_COUNT, DOT_PRODUCT_STRIP_SIZE},
@@ -26,6 +24,7 @@ use crate::target::{
 };
 use crate::utils::{indent, LinePrefixWrite, ASCII_CHARS};
 use crate::views::{Param, Tensor, View};
+use crate::{dimsize, shape};
 
 const STACK_CUTOFF: u32 = 256;
 
@@ -951,7 +950,7 @@ impl<'a, Tgt: CpuTarget> CpuCodeGenerator<'a, Tgt> {
 
                         let (shift_fn, blend_fn, zero_fn, _) = vec_func_names(16);
 
-                        let vf32 = get_vector(Tgt::vec_types(), Dtype::Float32, nz!(8u32));
+                        let vf32 = get_vector(Tgt::vec_types(), Dtype::Float32, dimsize!(8));
                         let vbf16 = get_vector(
                             Tgt::vec_types(),
                             Dtype::Bfloat16,
@@ -1063,7 +1062,7 @@ impl<'a, Tgt: CpuTarget> CpuCodeGenerator<'a, Tgt> {
                             })
                             .collect::<Vec<_>>();
 
-                        let vf32 = get_vector(Tgt::vec_types(), Dtype::Float32, nz!(8u32));
+                        let vf32 = get_vector(Tgt::vec_types(), Dtype::Float32, dimsize!(8));
                         let vbf16 = get_vector(
                             Tgt::vec_types(),
                             Dtype::Bfloat16,
@@ -1183,7 +1182,7 @@ impl<'a, Tgt: CpuTarget> CpuCodeGenerator<'a, Tgt> {
                             })
                             .collect::<Vec<_>>();
 
-                        let vf32 = get_vector(Tgt::vec_types(), Dtype::Float32, nz!(8u32));
+                        let vf32 = get_vector(Tgt::vec_types(), Dtype::Float32, dimsize!(8));
                         let vbf16 = get_vector(
                             Tgt::vec_types(),
                             Dtype::Bfloat16,
@@ -1358,13 +1357,13 @@ impl<'a, Tgt: CpuTarget> CpuCodeGenerator<'a, Tgt> {
                         let intermediate_dtype = arguments[0].spec().dtype();
                         let intermediate_lower = self.make_buffer(
                             &shape![1, 32],
-                            Some(nz!(32u32)),
+                            Some(dimsize!(32)),
                             intermediate_dtype,
                             VRF,
                         );
                         let intermediate_higher = self.make_buffer(
                             &shape![1, 32],
-                            Some(nz!(32u32)),
+                            Some(dimsize!(32)),
                             intermediate_dtype,
                             VRF,
                         );
@@ -1426,7 +1425,7 @@ impl<'a, Tgt: CpuTarget> CpuCodeGenerator<'a, Tgt> {
 
                         let (shift_fn, blend_fn, zero_fn, _) = vec_func_names(16);
 
-                        let vf8 = get_vector(Tgt::vec_types(), Dtype::Float32, nz!(8u32));
+                        let vf8 = get_vector(Tgt::vec_types(), Dtype::Float32, dimsize!(8));
                         writeln!(
                             w,
                             "{0}{2} = ({1}){shift_fn}(*({3}*)(&{4}), 16);",

--- a/morello/src/db.rs
+++ b/morello/src/db.rs
@@ -235,7 +235,7 @@ impl RocksDatabase {
         let (table_key, global_pt_lhs) = bimap.apply(lhs);
         let (block_pt, _) = blockify_point(global_pt_lhs);
         PageId {
-            db: &self,
+            db: self,
             table_key,
             superblock_id: superblockify_pt(&block_pt),
         }
@@ -1094,7 +1094,7 @@ mod tests {
 
             // Put all decisions into database.
             for d in decision.visit_decisions() {
-                db.put(d.spec.clone(), d.actions_costs.clone().into());
+                db.put(d.spec.clone(), d.actions_costs.clone());
             }
 
             let peaks = if let Some((_, c)) = decision.actions_costs.first() {
@@ -1111,7 +1111,7 @@ mod tests {
                     bit_length(p)..=bit_length(l)
                 })
                 .multi_cartesian_product();
-            let expected = ActionCostVec(decision.actions_costs.into());
+            let expected = ActionCostVec(decision.actions_costs);
             for limit_to_check_bits in filled_limits_iter {
                 let limit_to_check_vec = limit_to_check_bits.iter().copied().map(bit_length_inverse).collect::<Vec<_>>();
                 let limit_to_check = MemoryLimits::Standard(MemVec::new(limit_to_check_vec.try_into().unwrap()));

--- a/morello/src/layout.rs
+++ b/morello/src/layout.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use std::{collections::HashSet, fmt::Display, hash::Hash};
 
-#[cfg(any(debug_assertions, test))]
+#[cfg(test)]
 use nonzero::nonzero as nz;
 
 use crate::{
@@ -583,7 +583,7 @@ impl Layout {
             for (_, size) in dims {
                 debug_assert_ne!(
                     size,
-                    &PhysDim::Packed(nz!(1u32)),
+                    &PhysDim::Packed(crate::dimsize!(1)),
                     "Size-1 packing in layout: {:?}",
                     dims
                 );
@@ -741,13 +741,13 @@ pub mod macros {
         };
         ( @inner ($dim:expr, PhysDim::OddEven($ds:expr)) ) => {{
             use $crate::layout::PhysDim;
-            use $crate::spec::macros::internal::IntoDimSize;
-            ($dim, PhysDim::OddEven(($ds).into_dim_size()))
+            use $crate::dimsize;
+            ($dim, PhysDim::OddEven(dimsize!($ds)))
         }};
         ( @inner ($dim:expr, PhysDim::Packed($ds:expr)) ) => {{
             use $crate::layout::PhysDim;
-            use $crate::spec::macros::internal::IntoDimSize;
-            ($dim, PhysDim::Packed(($ds).into_dim_size()))
+            use $crate::dimsize;
+            ($dim, PhysDim::Packed(dimsize!($ds)))
         }};
         ( @inner ($dim:expr, PhysDim::Dynamic) ) => {{
             use $crate::layout::PhysDim;

--- a/morello/src/scheduling.rs
+++ b/morello/src/scheduling.rs
@@ -1,4 +1,3 @@
-use nonzero::nonzero as nz;
 use serde::{Deserialize, Serialize};
 
 use std::fmt::Display;
@@ -7,6 +6,7 @@ use std::{iter, mem};
 
 use crate::alignment::aligned_approx;
 use crate::common::{DimSize, Dtype, Shape};
+use crate::dimsize;
 use crate::imp::blocks::Block;
 use crate::imp::kernels::KernelApp;
 use crate::imp::loops::{Loop, LoopTile};
@@ -376,9 +376,7 @@ impl<Tgt: Target> Action<Tgt> {
                     let intermediate_mem_consumed_nondiscrete = Tgt::levels().map(|l| {
                         if level == &l {
                             u64::from(next_to_outer_basics.dtypes[ntob_out_idx].size())
-                                * u64::from(
-                                    output_shape.into_iter().map(|d| d.get()).product::<u32>(),
-                                )
+                                * u64::from(output_shape.iter().map(|d| d.get()).product::<u32>())
                         } else {
                             0u64
                         }
@@ -454,7 +452,7 @@ impl<Tgt: Target> Action<Tgt> {
                 let [outer_image_tile, outer_filters_tile] = [0, 1].map(|idx| {
                     let shape = operands[idx].shape()[..2]
                         .iter()
-                        .chain(iter::repeat(&nz!(1u32)).take((rank - 2).into()))
+                        .chain(iter::repeat(&dimsize!(1)).take((rank - 2).into()))
                         .copied()
                         .collect::<Shape>();
                     let step_sizes = shape.clone();

--- a/morello/src/search.rs
+++ b/morello/src/search.rs
@@ -827,19 +827,19 @@ mod tests {
     use crate::common::DimSize;
     use crate::db::RocksDatabase;
     use crate::layout::row_major;
-    use crate::lspec;
     use crate::memorylimits::{MemVec, MemoryLimits};
     use crate::spec::{arb_canonical_spec, LogicalSpec, PrimitiveBasics, PrimitiveSpecType};
     use crate::target::{CpuMemoryLevel::GL, X86Target};
     use crate::tensorspec::TensorSpecAux;
     use crate::utils::{bit_length, bit_length_inverse};
+    use crate::{dimsize, lspec};
     use nonzero::nonzero as nz;
     use proptest::prelude::*;
     use proptest::sample::select;
 
     use std::rc::Rc;
 
-    const TEST_SMALL_SIZE: DimSize = nz!(2u32);
+    const TEST_SMALL_SIZE: DimSize = dimsize!(2);
     const TEST_SMALL_MEM: u64 = 2048;
 
     proptest! {

--- a/morello/src/tiling.rs
+++ b/morello/src/tiling.rs
@@ -119,15 +119,14 @@ impl Tiling {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::shape;
+    use crate::{dimsize, shape};
     use itertools::Itertools;
-    use nonzero::nonzero as nz;
     use proptest::prelude::*;
     use proptest::proptest;
     use std::cmp::max;
 
     const ALLOW_ARBITRARY_SLIDES: bool = false;
-    const MAX_ORIGIN_SIZE: DimSize = nz!(20u32);
+    const MAX_ORIGIN_SIZE: DimSize = dimsize!(20);
 
     /// A Strategy for generating valid Shapes.
     fn shape_strategy(max_size: DimSize, max_dims: u8) -> impl Strategy<Value = Shape> {
@@ -137,7 +136,7 @@ mod tests {
 
     /// A Strategy for generating valid Tilings.
     fn tiling_strategy(dims: u8) -> impl Strategy<Value = Tiling> {
-        shape_strategy(nz!(4u32), dims)
+        shape_strategy(dimsize!(4), dims)
             .prop_flat_map(|shp| {
                 let rank = shp.len();
                 if ALLOW_ARBITRARY_SLIDES {
@@ -181,7 +180,13 @@ mod tests {
 
     #[test]
     fn test_tiling_sliding() {
-        const OUTER_SHAPE: [DimSize; 5] = [nz!(1u32), nz!(4u32), nz!(2u32), nz!(4u32), nz!(4u32)];
+        const OUTER_SHAPE: [DimSize; 5] = [
+            dimsize!(1),
+            dimsize!(4),
+            dimsize!(2),
+            dimsize!(4),
+            dimsize!(4),
+        ];
         let t = Tiling::new_sliding(shape![1, 3, 1, 3, 3], shape![1, 3, 2, 1, 1]);
         assert_eq!(t.steps_dim(0, OUTER_SHAPE[0]), 1);
         assert_eq!(t.steps_dim(1, OUTER_SHAPE[1]), 2);


### PR DESCRIPTION
This patch removes some runtime nonzero checks by checking them at compile time. It also removes unnecessary `.into()` calls, but I think this did not affect the improvements, as I think the compiler knew this.

5f239e551f5348607f0f4ab684b2d99aaac4471b -> this patch

```
synth::synth_group::synth_matmul multiple_0:1
  Instructions:           114410551|114657093       (-0.21503%) [-1.00215x]
  L1 Hits:                155870699|156179590       (-0.19778%) [-1.00198x]
  L2 Hits:                  1176339|1212302         (-2.96651%) [-1.03057x]
  RAM Hits:                   74423|74498           (-0.10067%) [-1.00101x]
  Total read+write:       157121461|157466390       (-0.21905%) [-1.00220x]
  Estimated Cycles:       164357199|164848530       (-0.29805%) [-1.00299x]
```