### PR TITLE
Supported automatically detecting target architecture.

### DIFF
--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -56,7 +56,7 @@ struct Args {
     impl_style: ImplPrintStyle,
 
     /// Target architecture
-    #[arg(long, value_enum, default_value_t = TargetId::X86)]
+    #[arg(long, value_enum, default_value_t = TargetId::default())]
     target: TargetId,
 
     /// Number of parallel jobs for top-down search

--- a/morello/src/target/mod.rs
+++ b/morello/src/target/mod.rs
@@ -89,3 +89,13 @@ pub enum TargetId {
     X86,
     Arm,
 }
+
+impl Default for TargetId {
+    fn default() -> Self {
+        match std::env::consts::ARCH {
+            "x86" | "x86_64" => TargetId::X86,
+            "arm" | "aarch64" => TargetId::Arm,
+            arch => unimplemented!("Architecture {} not supported", arch),
+        }
+    }
+}


### PR DESCRIPTION
This patch supports automatic target architecture detection at runtime.  I confirmed that the target architecture is correctly detected in two different environments.

On M1 mac:

```
$ cargo run -- -h
...
      --target <TARGET>          Target architecture [default: arm] [possible values: x86, arm]
...
```

On x86 laptop:

```
$ cargo run -- -h
...
      --target <TARGET>          Target architecture [default: x86] [possible values: x86, arm]
...
```