### PR TITLE
Removed unnecessary .into.

### DIFF
--- a/morello/src/db.rs
+++ b/morello/src/db.rs
@@ -235,7 +235,7 @@ impl RocksDatabase {
         let (table_key, global_pt_lhs) = bimap.apply(lhs);
         let (block_pt, _) = blockify_point(global_pt_lhs);
         PageId {
-            db: &self,
+            db: self,
             table_key,
             superblock_id: superblockify_pt(&block_pt),
         }
@@ -1094,7 +1094,7 @@ mod tests {
 
             // Put all decisions into database.
             for d in decision.visit_decisions() {
-                db.put(d.spec.clone(), d.actions_costs.clone().into());
+                db.put(d.spec.clone(), d.actions_costs.clone());
             }
 
             let peaks = if let Some((_, c)) = decision.actions_costs.first() {
@@ -1111,7 +1111,7 @@ mod tests {
                     bit_length(p)..=bit_length(l)
                 })
                 .multi_cartesian_product();
-            let expected = ActionCostVec(decision.actions_costs.into());
+            let expected = ActionCostVec(decision.actions_costs);
             for limit_to_check_bits in filled_limits_iter {
                 let limit_to_check_vec = limit_to_check_bits.iter().copied().map(bit_length_inverse).collect::<Vec<_>>();
                 let limit_to_check = MemoryLimits::Standard(MemVec::new(limit_to_check_vec.try_into().unwrap()));

--- a/morello/src/scheduling.rs
+++ b/morello/src/scheduling.rs
@@ -376,9 +376,7 @@ impl<Tgt: Target> Action<Tgt> {
                     let intermediate_mem_consumed_nondiscrete = Tgt::levels().map(|l| {
                         if level == &l {
                             u64::from(next_to_outer_basics.dtypes[ntob_out_idx].size())
-                                * u64::from(
-                                    output_shape.into_iter().map(|d| d.get()).product::<u32>(),
-                                )
+                                * u64::from(output_shape.iter().map(|d| d.get()).product::<u32>())
                         } else {
                             0u64
                         }

--- a/morello/src/spec.rs
+++ b/morello/src/spec.rs
@@ -461,7 +461,7 @@ impl proptest::arbitrary::Arbitrary for PrimitiveBasics {
                     .into_iter()
                     .map(|x| DimSize::new(x).unwrap())
                     .collect(),
-                dtypes: dtypes.into(),
+                dtypes,
             })
             .boxed()
     }
@@ -2263,7 +2263,7 @@ mod tests {
         let actual: Vec<Shape> = gen_tile_sizes::<X86Target>(&tensor_shape, drop_given, multi_dim)
             .map(|s| {
                 assert_eq!(s.len(), d);
-                s.into_iter().collect::<Vec<_>>().into()
+                s
             })
             .sorted()
             .collect::<Vec<_>>();


### PR DESCRIPTION
This patch also removes an unnecessary reference.

Related to: https://github.com/samkaufman/morello/pull/70#issuecomment-2123708079